### PR TITLE
Add Unit Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,15 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "dir-tree",
+			"name": "@fliegwerk/dir-tree",
 			"version": "0.2.1",
+			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^27.4.0",
+				"@types/mock-fs": "^4.13.1",
 				"@types/node": "^17.0.15",
 				"jest": "^27.5.0",
+				"mock-fs": "^5.1.2",
 				"prettier": "^2.5.1",
 				"rollup": "^2.67.1",
 				"rollup-plugin-commonjs": "^10.1.0",
@@ -19,6 +22,9 @@
 				"rollup-plugin-typescript2": "^0.31.2",
 				"ts-jest": "^27.1.3",
 				"typescript": "^4.5.5"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1040,6 +1046,15 @@
 			"dependencies": {
 				"jest-diff": "^27.0.0",
 				"pretty-format": "^27.0.0"
+			}
+		},
+		"node_modules/@types/mock-fs": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+			"integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/node": {
@@ -3298,6 +3313,15 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
+		"node_modules/mock-fs": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+			"integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5401,6 +5425,15 @@
 				"pretty-format": "^27.0.0"
 			}
 		},
+		"@types/mock-fs": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+			"integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/node": {
 			"version": "17.0.15",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
@@ -7124,6 +7157,12 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"mock-fs": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.2.tgz",
+			"integrity": "sha512-YkjQkdLulFrz0vD4BfNQdQRVmgycXTV7ykuHMlyv+C8WCHazpkiQRDthwa02kSyo8wKnY9wRptHfQLgmf0eR+A==",
 			"dev": true
 		},
 		"ms": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,10 @@
 	],
 	"devDependencies": {
 		"@types/jest": "^27.4.0",
+		"@types/mock-fs": "^4.13.1",
 		"@types/node": "^17.0.15",
 		"jest": "^27.5.0",
+		"mock-fs": "^5.1.2",
 		"prettier": "^2.5.1",
 		"rollup": "^2.67.1",
 		"rollup-plugin-commonjs": "^10.1.0",

--- a/src/dir-tree.spec.ts
+++ b/src/dir-tree.spec.ts
@@ -1,9 +1,101 @@
 import { dirTree } from './dir-tree';
-import { join } from 'path';
+import { resolve } from 'path';
+import mockFS from 'mock-fs';
+import {
+	DirectoryElement,
+	LinkElement,
+	UnreadableElement
+} from './tree-element';
 
-it('should successfully parse the .github directory', async () => {
-	const result = await dirTree(join(__dirname, '..', '.github'));
-	expect(result).toMatchObject({
-		type: 'directory'
+beforeEach(() => {
+	mockFS({
+		'/flat': {
+			'a.ts': 'Hello world',
+			'b.ts': 'Another file'
+		},
+		'/not-so-flat': {
+			a: {
+				'a.ts': 'Hello world',
+				'b.ts': 'Another file'
+			},
+			b: {
+				'a.ts': 'Hello world',
+				'b.ts': 'Another file'
+			},
+			c: {
+				'a.ts': 'Hello world',
+				'b.ts': 'Another file'
+			}
+		},
+		'/link': mockFS.symlink({
+			path: '/flat'
+		})
+	});
+});
+
+afterEach(() => {
+	mockFS.restore();
+});
+
+it('should successfully parse a flat directory', async () => {
+	const result = await dirTree('/flat');
+
+	expect(result).toMatchObject<DirectoryElement>({
+		type: 'directory',
+		name: 'flat',
+		ext: '',
+		path: resolve('/flat'),
+		children: [
+			{
+				type: 'file',
+				name: 'a.ts',
+				ext: '.ts',
+				path: resolve('/flat/a.ts')
+			},
+			{
+				type: 'file',
+				name: 'b.ts',
+				ext: '.ts',
+				path: resolve('/flat/b.ts')
+			}
+		]
+	});
+});
+
+it('should successfully parse a deep directory', async () => {
+	const result = await dirTree('/not-so-flat');
+	expect(result).toMatchObject<Partial<DirectoryElement>>({
+		type: 'directory',
+		name: 'not-so-flat',
+		ext: '',
+		path: resolve('/not-so-flat')
+	});
+	expect(result).toHaveProperty('children');
+	if (result.type === 'directory') {
+		expect(result.children.length).toBe(3);
+	}
+});
+
+it('should successfully parse a symlink', async () => {
+	const result = await dirTree('/link');
+	expect(result).toMatchObject<LinkElement>({
+		type: 'link',
+		name: 'link',
+		ext: '',
+		path: resolve('/link'),
+		destination: resolve('/flat')
+	});
+});
+
+it('should fail return an UnreadableElement for non-existent files', async () => {
+	const result = await dirTree('/non-existent');
+	expect(result).toMatchObject<UnreadableElement>({
+		type: 'unreadable',
+		path: resolve('/non-existent'),
+		name: 'non-existent',
+		ext: '',
+		error: {
+			code: 'ENOENT'
+		}
 	});
 });


### PR DESCRIPTION
Adds a few unit tests surrounding our API function

## Caveats
The `mock-fs` library doesn't support anything but directories, files, and symlinks.
Because of this, we have one `else` branch in our code that these tests can't cover.

## Related issues
Closes: #4